### PR TITLE
Fix typo in documented methods

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -120,7 +120,7 @@ pub trait Endian: private::Sealed {
     where
         R: Read;
 
-    /// Reads an unsigned 16 bit integer from the given reader.
+    /// Reads an unsigned 64 bit integer from the given reader.
     ///
     /// # Errors
     ///
@@ -142,7 +142,7 @@ pub trait Endian: private::Sealed {
     where
         R: Read;
 
-    /// Reads an unsigned 16 bit integer from the given reader.
+    /// Reads an unsigned 128 bit integer from the given reader.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
`read_u64` and `read_u128` do not read 16 bit integers