### PR TITLE
Some lint fixes

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -24,7 +24,7 @@ where
 {
     fn new_default(inner: T) -> Self {
         ByteOrdered {
-            inner: inner,
+            inner,
             endianness: Default::default(),
         }
     }
@@ -81,8 +81,8 @@ impl<T> ByteOrdered<T, Endianness> {
 impl<T, E> From<(T, E)> for ByteOrdered<T, E> {
     fn from((inner, endianness): (T, E)) -> Self {
         ByteOrdered {
-            inner: inner,
-            endianness: endianness,
+            inner,
+            endianness,
         }
     }
 }
@@ -110,8 +110,8 @@ where
     /// [`runtime`]: struct.ByteOrdered.html#method.runtime
     pub fn new(inner: T, endianness: E) -> Self {
         ByteOrdered {
-            inner: inner,
-            endianness: endianness,
+            inner,
+            endianness,
         }
     }
 

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -25,11 +25,11 @@ fn test_macro_one_read() {
 #[test]
 fn test_macro_one_read_2() {
     let x: &[u8] = &[16, 1];
-    let v = with_order!(x, Endianness::Little, |data| { data.read_u16().unwrap() });
+    let v = with_order!(x, Endianness::Little, |data| data.read_u16().unwrap());
     assert_eq!(v, 272);
 
     let x: &[u8] = &[1, 16];
-    let v = with_order!(x, Endianness::Big, |data| { data.read_u16().unwrap() });
+    let v = with_order!(x, Endianness::Big, |data| data.read_u16().unwrap());
     assert_eq!(v, 272);
 }
 


### PR DESCRIPTION
- Remove unnecessary braces in `test_macro_one_read_2`
- fix clippy lint for exhaustive specification of field names in struct initialization (non-exhaustive form is supported since 1.40) 